### PR TITLE
[P2P] Generate private key using cryptography

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -26,7 +26,7 @@ from aleph.config import get_defaults
 from aleph.jobs import start_jobs, prepare_loop, prepare_manager, DBManager
 from aleph.network import listener_tasks
 from aleph.services import p2p
-from aleph.services.p2p.manager import generate_keypair
+from aleph.services.p2p.keys import generate_keypair
 from aleph.web import app, init_cors
 
 
@@ -131,7 +131,7 @@ def main(args):
 
     if args.generate_key:
         LOGGER.info("Generating a key pair")
-        generate_keypair(args.print_key, args.key_path)
+        _ = generate_keypair(args.print_key, args.key_path)
         return
 
     LOGGER.info("Loading configuration")

--- a/src/aleph/services/p2p/keys.py
+++ b/src/aleph/services/p2p/keys.py
@@ -1,0 +1,57 @@
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKey,
+    RSAPublicKey,
+    generate_private_key,
+)
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+
+from typing import Optional, Tuple
+
+
+def create_new_key_pair(
+    key_size: int = 2048, exponent: int = 65537
+) -> Tuple[RSAPrivateKey, RSAPublicKey]:
+    private_key = generate_private_key(
+        backend=crypto_default_backend(), public_exponent=exponent, key_size=key_size
+    )
+
+    public_key = private_key.public_key()
+
+    return private_key, public_key
+
+
+def save_private_key(private_key: RSAPrivateKey, file_path: str) -> None:
+    with open(file_path, "wb") as f:
+        f.write(
+            private_key.private_bytes(
+                crypto_serialization.Encoding.PEM,
+                crypto_serialization.PrivateFormat.PKCS8,
+                crypto_serialization.NoEncryption(),
+            )
+        )
+
+
+def generate_keypair(
+    print_key: bool, key_path: Optional[str]
+) -> Tuple[RSAPrivateKey, RSAPublicKey]:
+    """Generate a key pair and exit."""
+    private_key, public_key = create_new_key_pair()
+
+    if print_key or key_path:
+        private_key_str = private_key.private_bytes(
+            crypto_serialization.Encoding.PEM,
+            crypto_serialization.PrivateFormat.PKCS8,
+            crypto_serialization.NoEncryption(),
+        ).decode("UTF-8")
+
+        if print_key:
+            # Print the armored key pair for archiving
+            print(private_key_str)
+
+        if key_path:
+            # Save the armored key pair in a file
+            with open(key_path, "w") as f:
+                f.write(private_key_str)
+
+    return private_key, public_key

--- a/src/aleph/services/p2p/manager.py
+++ b/src/aleph/services/p2p/manager.py
@@ -1,10 +1,10 @@
 import logging
-from typing import Optional, Coroutine, List, Tuple, Any
+from typing import Coroutine, List, Tuple, Any
 
 import multiaddr
 from Crypto.PublicKey.RSA import import_key
 from libp2p import new_node, BasicHost
-from libp2p.crypto.rsa import RSAPrivateKey, KeyPair, create_new_key_pair
+from libp2p.crypto.rsa import KeyPair, RSAPrivateKey
 from libp2p.pubsub import floodsub, gossipsub
 from libp2p.pubsub.pubsub import Pubsub
 
@@ -19,28 +19,18 @@ FLOODSUB_PROTOCOL_ID = floodsub.PROTOCOL_ID
 GOSSIPSUB_PROTOCOL_ID = gossipsub.PROTOCOL_ID
 
 
-def generate_keypair(print_key: bool, key_path: Optional[str]):
-    """Generate an key pair and exit."""
-    keypair = create_new_key_pair()
-    if print_key:
-        # Print the armored key pair for archiving
-        print(keypair.private_key.impl.export_key().decode("utf-8"))
-
-    if key_path:
-        # Save the armored key pair in a file
-        with open(key_path, "wb") as key_file:
-            key_file.write(keypair.private_key.impl.export_key())
-
-    return keypair
-
-
 # Save published adress to present them in the web process later
 public_adresses = []
 
 
 async def initialize_host(
-    key, host="0.0.0.0", port=4025, listen=True, protocol_active=True
+    key: str,
+    host: str = "0.0.0.0",
+    port: int = 4025,
+    listen: bool = True,
+    protocol_active: bool = True,
 ) -> Tuple[BasicHost, Pubsub, Any, List]:
+
     from .protocol import AlephProtocol
     from .jobs import reconnect_p2p_job, tidy_http_peers_job
 


### PR DESCRIPTION
Rewrote the private key generation method to use the cryptography
package instead of libp2p. This removes a dependency to libp2p
in preparation for its removal.