### PR TITLE
[Fix] Remove unused parameter in IPFS sub function

### DIFF
--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -138,8 +138,8 @@ def listener_tasks(config) -> List[Coroutine]:
 
     # for now (1st milestone), we only listen on a single global topic...
     tasks: List[Coroutine] = [
-        incoming_p2p_channel(config, config.aleph.queue_topic.value)
+        incoming_p2p_channel(config.aleph.queue_topic.value)
     ]
     if config.ipfs.enabled.value:
-        tasks.append(incoming_ipfs_channel(config, config.aleph.queue_topic.value))
+        tasks.append(incoming_ipfs_channel(config.aleph.queue_topic.value))
     return tasks

--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -1,11 +1,9 @@
 import asyncio
 import base64
 import logging
-from typing import Coroutine, List
-from aiohttp import ClientConnectorError
 import base58
 
-from .common import get_base_url, get_ipfs_api
+from .common import get_ipfs_api
 from aleph.types import InvalidMessageError
 
 
@@ -21,12 +19,7 @@ async def decode_msg(msg):
     }
 
 
-async def sub(topic, base_url=None):
-    if base_url is None:
-        from aleph.web import app
-
-        base_url = await get_base_url(app["config"])
-
+async def sub(topic: str):
     api = await get_ipfs_api()
 
     async for mvalue in api.pubsub.sub(topic):
@@ -46,7 +39,7 @@ async def pub(topic, message):
     await api.pubsub.pub(topic, message)
 
 
-async def incoming_channel(config, topic):
+async def incoming_channel(topic) -> None:
     from aleph.network import incoming_check
     from aleph.chains.common import incoming
 
@@ -58,7 +51,7 @@ async def incoming_channel(config, topic):
     while True:
         try:
             # seen_ids = []
-            async for mvalue in sub(topic, base_url=await get_base_url(config)):
+            async for mvalue in sub(topic):
                 try:
                     message = await incoming_check(mvalue)
                     LOGGER.debug("New message %r" % message)

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -195,7 +195,14 @@ class AlephProtocol(INotifee):
         return bool(len(self.peers[peer_id]))
 
 
-async def incoming_channel(config, topic):
+async def request_hash(item_hash):
+    if singleton.streamer is not None:
+        return await singleton.streamer.request_hash(item_hash)
+    else:
+        return None
+
+
+async def incoming_channel(topic: str) -> None:
     LOGGER.debug("incoming channel started...")
     from aleph.chains.common import delayed_incoming
 
@@ -220,10 +227,3 @@ async def incoming_channel(config, topic):
 
         except Exception:
             LOGGER.exception("Exception in pubsub, reconnecting.")
-
-
-async def request_hash(item_hash):
-    if singleton.streamer is not None:
-        return await singleton.streamer.request_hash(item_hash)
-    else:
-        return None


### PR DESCRIPTION
Removed the `base_url` parameter from `services.ipfs.pubsub` as
it was unused. Cleaned the callers.